### PR TITLE
fix: overlapping behavior of navbar with other elements on page refresh

### DIFF
--- a/src/components/navigation/navbar.tsx
+++ b/src/components/navigation/navbar.tsx
@@ -34,6 +34,10 @@ const Navbar = () => {
   };
 
   useEffect(() => {
+    //checks if page is already scrolled or not on page refresh
+    if (window.scrollY > 0) {
+      setScroll(true);
+    }
     window.addEventListener("scroll", handleScroll);
     return () => {
       window.removeEventListener("scroll", handleScroll);


### PR DESCRIPTION
When we scroll our page and do a refresh , previously the navbar was overlapping with other elements and animation was not working but now on page refresh we can see the navbar animation working perfectly